### PR TITLE
Fixes motor index issue

### DIFF
--- a/bOscLib/VRChatAvatar.cs
+++ b/bOscLib/VRChatAvatar.cs
@@ -41,7 +41,14 @@ namespace bHapticsOSC
                     continue;
                 Devices[device.Item2] = new Device(device.Item2);
                 for (int i = 1; i < device.Item1 + 1; i++)
-                    OscManager.Attach($"{device.Item3}_{i}_bool", (string address, OscMessage msg) => OnNode(msg, i, device.Item2));
+                {
+                    var path = $"{device.Item3}_{i}_bool";
+
+                    int motorIndex = i;
+                    OscManager.Attach(path, (string address, OscMessage msg) => OnNode(msg, motorIndex, device.Item2));
+                }
+
+                
             }
         }
 


### PR DESCRIPTION
There is a weired bug when i compile it. 
From OnNode Handler, motor index always gets the last value (4, 7, 21). 
By adding local variable, problem has been revolved. 